### PR TITLE
bug修复

### DIFF
--- a/simplest_ffmpeg_android_helloworld/jni/simplest_ffmpeg_helloworld.c
+++ b/simplest_ffmpeg_android_helloworld/jni/simplest_ffmpeg_helloworld.c
@@ -147,6 +147,7 @@ JNIEXPORT jstring Java_com_leixiaohua1020_sffmpegandroidhelloworld_MainActivity_
 	AVFilter *f_temp = (AVFilter *)avfilter_next(NULL);
 	while (f_temp != NULL){
 		sprintf(info, "%s[%10s]\n", info, f_temp->name);
+		f_temp = f_temp->next;
 	}
 	//LOGE("%s", info);
 


### PR DESCRIPTION
现象：
点击filter按钮，程序crash
原因：
指针没有向后移动，导致读取filter信息过程进入死循环。最终导致申请的缓冲区溢出，应用crash。